### PR TITLE
UTF 8 encode response for python3 api responses

### DIFF
--- a/riskiq/cli/dns.py
+++ b/riskiq/cli/dns.py
@@ -10,6 +10,7 @@ from riskiq.cli import util
 
 IP_REGEX = re.compile(r'^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.([0-9]{1,3}|\*|[0-9]{1,3}/[0-9]{1,2})$')
 
+
 def ip_hostname(addr):
     match = IP_REGEX.match(addr)
     if match:
@@ -24,14 +25,14 @@ def get_data(client, cmd, rrtype=None, hostname=None, ip=None):
     data = None
     if cmd == 'name':
         if ip is not None:
-            data = client.get_dns_ptr_by_ip(ip, rrtype=rrtype)
+            data = client.get_dns_ptr_by_ip(ip, rrtype=rrtype,maxresults=500)
         elif hostname is not None:
             data = client.get_dns_data_by_name(hostname, rrtype=rrtype)
         else:
             raise ValueError('No IP or hostname')
     elif cmd == 'data':
         if ip is not None:
-            data = client.get_dns_data_by_ip(ip, rrtype=rrtype)
+            data = client.get_dns_data_by_ip(ip, rrtype=rrtype,maxresults=500)
         elif hostname is not None:
             data = client.get_dns_data_by_data(hostname, rrtype=rrtype)
         else:

--- a/riskiq/cli/dns.py
+++ b/riskiq/cli/dns.py
@@ -25,14 +25,14 @@ def get_data(client, cmd, rrtype=None, hostname=None, ip=None):
     data = None
     if cmd == 'name':
         if ip is not None:
-            data = client.get_dns_ptr_by_ip(ip, rrtype=rrtype,maxresults=500)
+            data = client.get_dns_ptr_by_ip(ip, rrtype=rrtype, maxresults=500)
         elif hostname is not None:
             data = client.get_dns_data_by_name(hostname, rrtype=rrtype)
         else:
             raise ValueError('No IP or hostname')
     elif cmd == 'data':
         if ip is not None:
-            data = client.get_dns_data_by_ip(ip, rrtype=rrtype,maxresults=500)
+            data = client.get_dns_data_by_ip(ip, rrtype=rrtype, maxresults=500)
         elif hostname is not None:
             data = client.get_dns_data_by_data(hostname, rrtype=rrtype)
         else:

--- a/riskiq/render.py
+++ b/riskiq/render.py
@@ -2,6 +2,12 @@ import os
 
 from jinja2 import Template, Environment, PackageLoader
 
+
+try:
+    UNICODE_EXISTS = bool(type(unicode))
+except NameError:
+    unicode = lambda s: str(s,'UTF-8')
+
 def renderer(data, template_file, custom_template=None,
         verbose=False, oneline=False):
     """
@@ -17,4 +23,4 @@ def renderer(data, template_file, custom_template=None,
         template_file += '_oneline'
     env = Environment(loader=PackageLoader('riskiq', 'templates'))
     template = env.get_template(template_file)
-    return template.render(data=data, verbose=verbose).encode('utf-8').strip()
+    return unicode(template.render(data=data, verbose=verbose).encode('utf-8').strip())


### PR DESCRIPTION
Response weren't being formatted properly in python3.  Added an attempt to encode the responses in a backwards compatible way.